### PR TITLE
Fix - Change consumer location

### DIFF
--- a/core/repository/ActiveMQConsumerRepository.go
+++ b/core/repository/ActiveMQConsumerRepository.go
@@ -1,8 +1,12 @@
 package repository
 
-import "messages/core/entity"
+import (
+	"context"
+	"messages/core/entity"
+)
 
 type ActiveMQConsumerRepository interface {
-	Subscribe(name string, destType string, ch chan<- entity.ConsumerEvent) error
-	Unsubscribe() error
+	// Subscribe starts consuming from the given destination.
+	// Events are sent to the returned channel until ctx is cancelled.
+	Subscribe(ctx context.Context, name string, destType string) (<-chan entity.ConsumerEvent, error)
 }

--- a/core/repository/KafkaConsumerRepository.go
+++ b/core/repository/KafkaConsumerRepository.go
@@ -1,8 +1,12 @@
 package repository
 
-import "messages/core/entity"
+import (
+	"context"
+	"messages/core/entity"
+)
 
 type KafkaConsumerRepository interface {
-	Subscribe(topic string, ch chan<- entity.ConsumerEvent) error
-	Unsubscribe() error
+	// Subscribe starts consuming from the given topic.
+	// Events are sent to the returned channel until ctx is cancelled.
+	Subscribe(ctx context.Context, topic string) (<-chan entity.ConsumerEvent, error)
 }

--- a/infrastructure/gateway/event/impl/ActiveMQConsumerRepositoryImpl.go
+++ b/infrastructure/gateway/event/impl/ActiveMQConsumerRepositoryImpl.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"context"
 	"fmt"
 	"messages/core/entity"
 	"messages/infrastructure/config"
@@ -12,8 +13,6 @@ import (
 
 type ActiveMQConsumerRepositoryImpl struct {
 	ActiveMQConfig config.ActiveMQConfig
-	conn           *stomp.Conn
-	sub            *stomp.Subscription
 }
 
 func NewActiveMQConsumerRepositoryImpl() *ActiveMQConsumerRepositoryImpl {
@@ -22,54 +21,48 @@ func NewActiveMQConsumerRepositoryImpl() *ActiveMQConsumerRepositoryImpl {
 	}
 }
 
-func (impl *ActiveMQConsumerRepositoryImpl) Subscribe(name string, destType string, ch chan<- entity.ConsumerEvent) error {
+func (impl *ActiveMQConsumerRepositoryImpl) Subscribe(ctx context.Context, name string, destType string) (<-chan entity.ConsumerEvent, error) {
 	conn, err := stomp.Dial("tcp", impl.ActiveMQConfig.GetBroker(),
 		stomp.ConnOpt.Login(impl.ActiveMQConfig.GetUser(), impl.ActiveMQConfig.GetPassword()),
 	)
 	if err != nil {
-		return fmt.Errorf("error connecting to ActiveMQ: %w", err)
+		return nil, fmt.Errorf("error connecting to ActiveMQ: %w", err)
 	}
-	impl.conn = conn
 
 	destination := fmt.Sprintf("/%s/%s", destType, name)
 	sub, err := conn.Subscribe(destination, stomp.AckAuto)
 	if err != nil {
 		conn.Disconnect()
-		return fmt.Errorf("error subscribing to %s: %w", destination, err)
+		return nil, fmt.Errorf("error subscribing to %s: %w", destination, err)
 	}
-	impl.sub = sub
+
+	ch := make(chan entity.ConsumerEvent, 128)
 
 	go func() {
 		defer close(ch)
-		for msg := range sub.C {
-			if msg.Err != nil {
+		defer conn.Disconnect()
+		for {
+			select {
+			case msg, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				if msg.Err != nil {
+					return
+				}
+				ch <- entity.ConsumerEvent{
+					ID:         uuid.NewString(),
+					Source:     "activemq",
+					Name:       name,
+					Payload:    string(msg.Body),
+					ReceivedAt: time.Now(),
+				}
+			case <-ctx.Done():
+				sub.Unsubscribe()
 				return
-			}
-			ch <- entity.ConsumerEvent{
-				ID:         uuid.NewString(),
-				Source:     "activemq",
-				Name:       name,
-				Payload:    string(msg.Body),
-				ReceivedAt: time.Now(),
 			}
 		}
 	}()
 
-	return nil
-}
-
-func (impl *ActiveMQConsumerRepositoryImpl) Unsubscribe() error {
-	if impl.sub != nil {
-		if err := impl.sub.Unsubscribe(); err != nil {
-			return err
-		}
-		impl.sub = nil
-	}
-	if impl.conn != nil {
-		if err := impl.conn.Disconnect(); err != nil {
-			return err
-		}
-		impl.conn = nil
-	}
-	return nil
+	return ch, nil
 }

--- a/infrastructure/gateway/event/impl/KafkaConsumerRepositoryImpl.go
+++ b/infrastructure/gateway/event/impl/KafkaConsumerRepositoryImpl.go
@@ -13,7 +13,6 @@ import (
 
 type KafkaConsumerRepositoryImpl struct {
 	KafkaConfig config.KafkaConfig
-	cancel      context.CancelFunc
 }
 
 func NewKafkaConsumerRepositoryImpl() *KafkaConsumerRepositoryImpl {
@@ -22,7 +21,7 @@ func NewKafkaConsumerRepositoryImpl() *KafkaConsumerRepositoryImpl {
 	}
 }
 
-func (impl *KafkaConsumerRepositoryImpl) Subscribe(topic string, ch chan<- entity.ConsumerEvent) error {
+func (impl *KafkaConsumerRepositoryImpl) Subscribe(ctx context.Context, topic string) (<-chan entity.ConsumerEvent, error) {
 	// No GroupID: reads directly from the partition without consumer group coordination.
 	// This avoids rebalancing delays and starts receiving messages immediately.
 	reader := kafka.NewReader(kafka.ReaderConfig{
@@ -31,8 +30,7 @@ func (impl *KafkaConsumerRepositoryImpl) Subscribe(topic string, ch chan<- entit
 		StartOffset: kafka.LastOffset,
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	impl.cancel = cancel
+	ch := make(chan entity.ConsumerEvent, 128)
 
 	log.Printf("[kafka-consumer] subscribed to topic=%s broker=%s", topic, impl.KafkaConfig.GetBroker())
 
@@ -60,13 +58,5 @@ func (impl *KafkaConsumerRepositoryImpl) Subscribe(topic string, ch chan<- entit
 		}
 	}()
 
-	return nil
-}
-
-func (impl *KafkaConsumerRepositoryImpl) Unsubscribe() error {
-	if impl.cancel != nil {
-		impl.cancel()
-		impl.cancel = nil
-	}
-	return nil
+	return ch, nil
 }

--- a/infrastructure/gateway/web/controller/ConsumerController.go
+++ b/infrastructure/gateway/web/controller/ConsumerController.go
@@ -6,67 +6,45 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	useCases "messages/core/use-cases"
-	"messages/core/services"
+	"messages/core/repository"
 	"messages/infrastructure/config"
 )
 
 type ConsumerControllerImpl struct {
-	ConsumeMessages useCases.ConsumeMessages
-	EventStore      services.EventStore
-}
-
-type startRequestDto struct {
-	Source   string `json:"source" validate:"required,oneof=kafka activemq"`
-	Name     string `json:"name" validate:"required"`
-	DestType string `json:"type" validate:"required,oneof=topic queue"`
+	KafkaConsumer    repository.KafkaConsumerRepository
+	ActiveMQConsumer repository.ActiveMQConsumerRepository
 }
 
 func NewConsumerController(
-	consumeMessages useCases.ConsumeMessages,
-	eventStore services.EventStore,
+	kafkaConsumer repository.KafkaConsumerRepository,
+	activeMQConsumer repository.ActiveMQConsumerRepository,
 ) chi.Router {
 	router := chi.NewRouter()
-	consumerEndpoints(router, &ConsumerControllerImpl{
-		ConsumeMessages: consumeMessages,
-		EventStore:      eventStore,
-	})
+	impl := &ConsumerControllerImpl{
+		KafkaConsumer:    kafkaConsumer,
+		ActiveMQConsumer: activeMQConsumer,
+	}
+	router.Get("/events", impl.StreamEvents)
 	return router
 }
 
-func consumerEndpoints(router chi.Router, impl *ConsumerControllerImpl) {
-	router.Post("/start", impl.Start)
-	router.Post("/stop", impl.Stop)
-	router.Get("/events", impl.StreamEvents)
-	router.Delete("/events", impl.ClearEvents)
-}
-
-func (impl *ConsumerControllerImpl) Start(writer http.ResponseWriter, request *http.Request) {
-	body, err := config.GetBody[startRequestDto](request.Body)
-	if err != nil {
-		config.ErrorResponse(writer, http.StatusBadRequest, err)
-		return
-	}
-	if err := impl.ConsumeMessages.Start(body.Source, body.Name, body.DestType); err != nil {
-		config.ErrorResponse(writer, http.StatusInternalServerError, err)
-		return
-	}
-	writer.WriteHeader(http.StatusOK)
-}
-
-func (impl *ConsumerControllerImpl) Stop(writer http.ResponseWriter, request *http.Request) {
-	if err := impl.ConsumeMessages.Stop(); err != nil {
-		config.ErrorResponse(writer, http.StatusInternalServerError, err)
-		return
-	}
-	writer.WriteHeader(http.StatusOK)
-}
-
 func (impl *ConsumerControllerImpl) StreamEvents(writer http.ResponseWriter, request *http.Request) {
-	writer.Header().Set("Content-Type", "text/event-stream")
-	writer.Header().Set("Cache-Control", "no-cache")
-	writer.Header().Set("Connection", "keep-alive")
-	writer.Header().Set("Access-Control-Allow-Origin", "*")
+	source := request.URL.Query().Get("source")
+	name := request.URL.Query().Get("name")
+	destType := request.URL.Query().Get("type")
+
+	if source == "" || name == "" {
+		config.ErrorResponse(writer, http.StatusBadRequest, fmt.Errorf("source and name are required"))
+		return
+	}
+	if source != "kafka" && source != "activemq" {
+		config.ErrorResponse(writer, http.StatusBadRequest, fmt.Errorf("source must be kafka or activemq"))
+		return
+	}
+	if source == "activemq" && destType == "" {
+		config.ErrorResponse(writer, http.StatusBadRequest, fmt.Errorf("type is required for activemq"))
+		return
+	}
 
 	flusher, ok := writer.(http.Flusher)
 	if !ok {
@@ -74,33 +52,38 @@ func (impl *ConsumerControllerImpl) StreamEvents(writer http.ResponseWriter, req
 		return
 	}
 
-	// Send history first
-	for _, event := range impl.EventStore.History() {
-		data, _ := json.Marshal(event)
-		fmt.Fprintf(writer, "data: %s\n\n", data)
-	}
-	flusher.Flush()
+	ctx := request.Context()
 
-	// Subscribe to live events
-	ch := impl.EventStore.Subscribe()
-	defer impl.EventStore.Unsubscribe(ch)
+	writer.Header().Set("Content-Type", "text/event-stream")
+	writer.Header().Set("Cache-Control", "no-cache")
+	writer.Header().Set("Connection", "keep-alive")
+	writer.Header().Set("Access-Control-Allow-Origin", "*")
 
-	for {
-		select {
-		case event, ok := <-ch:
-			if !ok {
-				return
-			}
+	switch source {
+	case "kafka":
+		eventCh, err := impl.KafkaConsumer.Subscribe(ctx, name)
+		if err != nil {
+			fmt.Fprintf(writer, "event: error\ndata: %s\n\n", err.Error())
+			flusher.Flush()
+			return
+		}
+		for event := range eventCh {
 			data, _ := json.Marshal(event)
 			fmt.Fprintf(writer, "data: %s\n\n", data)
 			flusher.Flush()
-		case <-request.Context().Done():
+		}
+
+	case "activemq":
+		eventCh, err := impl.ActiveMQConsumer.Subscribe(ctx, name, destType)
+		if err != nil {
+			fmt.Fprintf(writer, "event: error\ndata: %s\n\n", err.Error())
+			flusher.Flush()
 			return
 		}
+		for event := range eventCh {
+			data, _ := json.Marshal(event)
+			fmt.Fprintf(writer, "data: %s\n\n", data)
+			flusher.Flush()
+		}
 	}
-}
-
-func (impl *ConsumerControllerImpl) ClearEvents(writer http.ResponseWriter, request *http.Request) {
-	impl.EventStore.Clear()
-	writer.WriteHeader(http.StatusNoContent)
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/joho/godotenv"
-	"messages/core/services"
 	useCases "messages/core/use-cases"
 	"messages/infrastructure/gateway/event/impl"
 	"messages/infrastructure/gateway/web/controller"
@@ -26,25 +25,16 @@ func main() {
 	router := chi.NewRouter()
 	router.Use(middleware.Logger)
 
-	// Repository Impl
+	// Producer
 	kafkaRepository := impl.NewKafkaRepositoryImpl()
 	activeMQRepository := impl.NewActiveMqRepositoryImpl()
-
-	// Use cases
-	sendTopicsAndQueues := useCases.NewSendTopicsAndQueues(
-		kafkaRepository,
-		activeMQRepository,
-	)
-
+	sendTopicsAndQueues := useCases.NewSendTopicsAndQueues(kafkaRepository, activeMQRepository)
 	router.Mount("/messages", controller.NewMessageController(sendTopicsAndQueues))
 
-	// Consumer
-	eventStore := services.NewEventStore()
+	// Consumer (per-client, lifecycle tied to SSE connection)
 	kafkaConsumer := impl.NewKafkaConsumerRepositoryImpl()
 	activeMQConsumer := impl.NewActiveMQConsumerRepositoryImpl()
-	consumeMessages := useCases.NewConsumeMessages(kafkaConsumer, activeMQConsumer, eventStore)
-
-	router.Mount("/consumer", controller.NewConsumerController(consumeMessages, eventStore))
+	router.Mount("/consumer", controller.NewConsumerController(kafkaConsumer, activeMQConsumer))
 
 	// Static files (embedded)
 	subFS, err := fs.Sub(staticFiles, "static")
@@ -61,6 +51,5 @@ func main() {
 	println("Server started on port " + port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%s", port), router); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
-		return
 	}
 }

--- a/static/app.js
+++ b/static/app.js
@@ -83,55 +83,20 @@ function app() {
     start() {
       this.errorMsg = '';
       this.saveSettings();
-
-      // Clear events before starting a new consumer session
       this.events = [];
-      fetch('/consumer/events', { method: 'DELETE' });
 
-      const body = {
+      const params = new URLSearchParams({
         source: this.source,
-        name: this.name.trim(),
-        type: this.source === 'kafka' ? 'topic' : this.destType,
-      };
+        name:   this.name.trim(),
+        type:   this.source === 'kafka' ? 'topic' : this.destType,
+      });
 
-      fetch('/consumer/start', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-        .then(res => {
-          if (!res.ok) return res.json().then(e => { throw new Error(e.error || 'Unknown error'); });
-          this.isConnected = true;
-          this.openSSE();
-        })
-        .catch(err => { this.errorMsg = 'Error: ' + err.message; });
-    },
-
-    stop() {
-      fetch('/consumer/stop', { method: 'POST' })
-        .finally(() => {
-          this.isConnected = false;
-          if (this.eventSource) {
-            this.eventSource.close();
-            this.eventSource = null;
-          }
-        });
-    },
-
-    clear() {
-      fetch('/consumer/events', { method: 'DELETE' })
-        .then(() => { this.events = []; });
-    },
-
-    openSSE() {
       if (this.eventSource) this.eventSource.close();
-
-      this.eventSource = new EventSource('/consumer/events');
+      this.eventSource = new EventSource('/consumer/events?' + params.toString());
 
       this.eventSource.onmessage = (e) => {
         const event = JSON.parse(e.data);
         this.events.push(event);
-
         if (this.autoScroll) {
           this.$nextTick(() => {
             const list = document.getElementById('events-list');
@@ -140,10 +105,29 @@ function app() {
         }
       };
 
-      this.eventSource.onerror = () => {
-        this.isConnected = false;
+      this.eventSource.addEventListener('error', (e) => {
+        // Only treat it as a fatal error if the connection was never established
+        // or the server sent an explicit error event.
+        if (e.type === 'error' && this.eventSource.readyState === EventSource.CLOSED) {
+          this.isConnected = false;
+          this.eventSource = null;
+          this.errorMsg = 'Connection lost.';
+        }
+      });
+
+      this.isConnected = true;
+    },
+
+    stop() {
+      if (this.eventSource) {
+        this.eventSource.close();
         this.eventSource = null;
-      };
+      }
+      this.isConnected = false;
+    },
+
+    clear() {
+      this.events = [];
     },
 
     // --- Helpers ---


### PR DESCRIPTION
This pull request refactors the consumer message streaming architecture to simplify the lifecycle and interface for Kafka and ActiveMQ consumers. It removes the previous start/stop endpoints and event store, replacing them with a direct, per-client streaming approach using server-sent events (SSE). The consumer repositories and controller are updated to use context-based subscriptions and to expose a unified streaming endpoint.

**Consumer Streaming Refactor**

* The `KafkaConsumerRepository` and `ActiveMQConsumerRepository` interfaces now provide a context-aware `Subscribe` method that returns a channel of events, removing the need for explicit `Unsubscribe` and event store management. [[1]](diffhunk://#diff-20d6db7e3244fb770286aaca08efe0969b211a717ddd68c84bb256574f8a328fL3-R11) [[2]](diffhunk://#diff-22710680041ffe3291e5c145709c733ef9ceee68af37885068d1d6668e55d9d6L3-R11)
* The consumer repository implementations (`KafkaConsumerRepositoryImpl` and `ActiveMQConsumerRepositoryImpl`) are updated to use the new interface, managing their own connection lifecycle tied to the context and channel. [[1]](diffhunk://#diff-3b42f54e3485d957185203f0aadcfd433b6c105d120c2cd5996478a320972e72R4) [[2]](diffhunk://#diff-3b42f54e3485d957185203f0aadcfd433b6c105d120c2cd5996478a320972e72L15-L16) [[3]](diffhunk://#diff-3b42f54e3485d957185203f0aadcfd433b6c105d120c2cd5996478a320972e72L25-R49) [[4]](diffhunk://#diff-3b42f54e3485d957185203f0aadcfd433b6c105d120c2cd5996478a320972e72R60-R67) [[5]](diffhunk://#diff-9fba6643f74b1f13f73b2ef5da3ac0384519eafca5726b24ec0ad924314dca3dL16) [[6]](diffhunk://#diff-9fba6643f74b1f13f73b2ef5da3ac0384519eafca5726b24ec0ad924314dca3dL25-R24) [[7]](diffhunk://#diff-9fba6643f74b1f13f73b2ef5da3ac0384519eafca5726b24ec0ad924314dca3dL34-R33) [[8]](diffhunk://#diff-9fba6643f74b1f13f73b2ef5da3ac0384519eafca5726b24ec0ad924314dca3dL63-R61)

**Controller and Routing Changes**

* The `ConsumerControllerImpl` is refactored to remove the start/stop/clear endpoints and event store, exposing only a single `/consumer/events` streaming endpoint that directly subscribes to the appropriate consumer repository based on request parameters.

**Frontend Adaptation**

* The frontend (`static/app.js`) is updated to remove the start/stop/clear logic and now connects to the streaming endpoint with query parameters, handling connection lifecycle and errors directly. [[1]](diffhunk://#diff-d713c2909aaaea1243946874ecd850f3c40c0abeb6eb16cfb0ada05f1ed18ad5L86-L134) [[2]](diffhunk://#diff-d713c2909aaaea1243946874ecd850f3c40c0abeb6eb16cfb0ada05f1ed18ad5L143-R130)

**Application Initialization**

* The main application setup is simplified to remove event store and consumer use-case wiring, directly mounting the new controller with repository implementations. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L13) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L29-R37) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L64)